### PR TITLE
Remove redundant 'return' statement

### DIFF
--- a/favicon.go
+++ b/favicon.go
@@ -47,6 +47,5 @@ func New(path string) gin.HandlerFunc {
 		}
 		c.Header("Content-Type", "image/x-icon")
 		http.ServeContent(c.Writer, c.Request, "favicon.ico", info.ModTime(), reader)
-		return
 	}
 }


### PR DESCRIPTION
The function has no return value, final `return` statement is redundant.